### PR TITLE
Pipe response immediately

### DIFF
--- a/pages/reporting/index.js
+++ b/pages/reporting/index.js
@@ -13,6 +13,9 @@ module.exports = settings => {
   app.get('/:year', (req, res, next) => {
     const archive = archiver('zip');
 
+    res.attachment(`nts-${req.params.year}.zip`);
+    archive.pipe(res);
+
     req.api('/search/projects?limit=1')
       .then(response => {
         return req.api(`/search/projects?limit=${response.json.meta.count}`);
@@ -42,9 +45,7 @@ module.exports = settings => {
 
       })
       .then(() => {
-        res.attachment(`nts-${req.params.year}.zip`);
         archive.finalize();
-        archive.pipe(res);
       })
       .catch(err => next(err));
   });


### PR DESCRIPTION
By moving the stream up to the top of the function then nginx should see a response much earlier, and prevent it throwing a 504 timeout error.