### PR TITLE
Use project read url for project update

### DIFF
--- a/lib/urls.js
+++ b/lib/urls.js
@@ -24,6 +24,7 @@ module.exports = {
     read: '/establishments/:establishmentId/projects/:projectId',
     version: {
       read: '/establishments/:establishmentId/projects/:projectId/versions/:versionId',
+      update: '/establishments/:establishmentId/projects/:projectId/versions/:versionId',
       pdf: '/establishments/:establishmentId/projects/:projectId/versions/:versionId/pdf'
     }
   },


### PR DESCRIPTION
If an ASRU user attempt to access a project with an open draft then the project landing page throws an error because a URL for `project.version.update` is not defined.

The exact behaiour in this case is probably TBC, but using the read url for update at least prevents the error in the immediate term.