### PR TITLE
Don't render null expiry dates in project search results

### DIFF
--- a/pages/search/views/index.jsx
+++ b/pages/search/views/index.jsx
@@ -62,7 +62,7 @@ const formatters = {
     },
     expiryDate: {
       format: date => {
-        return <ExpiryDate date={date}/>;
+        return date ? <ExpiryDate date={date}/> : '-';
       }
     }
   }


### PR DESCRIPTION
If a project doesn't have an expiry date - i.e. is a draft - then don't render an expiry date of 1st Jan 1970.