### PR TITLE
Add metrics dashboard

### DIFF
--- a/assets/sass/app.scss
+++ b/assets/sass/app.scss
@@ -105,3 +105,14 @@ td .govuk-button {
     border-right: 3px solid govuk-colour('red');
   }
 }
+
+.metric {
+  p {
+    font-size: 80px;
+    font-weight: bold;
+    margin: 0;
+  }
+  padding-bottom: 5px;
+  border-bottom: 5px solid $govuk-brand-colour;
+  margin-bottom: $govuk-gutter;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,11 @@
         "url": "^0.11.0"
       },
       "dependencies": {
+        "date-fns": {
+          "version": "1.30.1",
+          "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+          "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
+        },
         "diff": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
@@ -89,6 +94,11 @@
             "govuk-elements-sass": "^3.1.2",
             "govuk-frontend": "^1.3.0"
           }
+        },
+        "date-fns": {
+          "version": "1.30.1",
+          "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+          "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
         },
         "image-size": {
           "version": "0.7.4",
@@ -169,6 +179,11 @@
         "webpack-cli": "^3.1.2"
       },
       "dependencies": {
+        "date-fns": {
+          "version": "1.30.1",
+          "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+          "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
+        },
         "deep-diff": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-1.0.2.tgz",
@@ -257,6 +272,11 @@
             "url": "^0.11.0"
           },
           "dependencies": {
+            "date-fns": {
+              "version": "1.30.1",
+              "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+              "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
+            },
             "mustache": {
               "version": "3.0.1",
               "resolved": "https://registry.npmjs.org/mustache/-/mustache-3.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "babel-loader": "^8.0.5",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "body-parser": "^1.18.3",
+    "date-fns": "^1.30.1",
     "docx": "^5.0.0-rc1",
     "express": "^4.16.4",
     "filenamify": "^4.0.0",

--- a/pages/reporting/content/index.js
+++ b/pages/reporting/content/index.js
@@ -1,0 +1,22 @@
+module.exports = {
+  'project-application': 'PPL applications',
+  'project-amendment': 'PPL amendments',
+  'pil-grant': 'PIL applications',
+  'pil-update': 'PIL amendments',
+  'pil-revoke': 'PIL revocations',
+  'role-create': 'Named people assignments',
+  'role-delete': 'Named people revocations',
+  'place-update': 'Approved area amendments',
+  'place-create': 'Approved area additions',
+  'place-delete': 'Approved area deletions',
+  'profile-update': 'Profile updates',
+  date: {
+    all: 'All',
+    week: 'This week',
+    month: 'This month',
+    year: 'This year'
+  },
+  breadcrumbs: {
+    metrics: 'Performance metrics'
+  }
+};

--- a/pages/reporting/index.js
+++ b/pages/reporting/index.js
@@ -52,6 +52,19 @@ module.exports = settings => {
       .catch(err => next(err));
   });
 
+  app.get('/', (req, res, next) => {
+    req.breadcrumb('metrics');
+    const since = req.query.since || '2019-07-31';
+    req.api(`/metrics?since=${since}`)
+      .then(response => {
+        res.locals.static.since = since;
+        res.locals.static.metrics = response.json;
+        next();
+      })
+      .catch(next);
+
+  });
+
   app.get('/', (req, res) => res.sendResponse());
 
   return app;

--- a/pages/reporting/views/index.jsx
+++ b/pages/reporting/views/index.jsx
@@ -1,19 +1,89 @@
 import React, { Fragment } from 'react';
-import { Header } from '@asl/components';
+import { connect } from 'react-redux';
+import { Header, Snippet } from '@asl/components';
+import { countBy } from 'lodash';
+import { format, startOfWeek, startOfMonth, startOfYear } from 'date-fns';
 
-const Index = () => (
-  <Fragment>
-    <Header title="Reports" />
+const Metric = ({ number, label }) => {
+  return <div className="metric">
+    <p>{ number }</p>
+    <label>{ label }</label>
+  </div>
+}
+
+const Index = ({ metrics, since }) => {
+  const types = [
+    'project-application',
+    'project-amendment',
+    'pil-grant',
+    'pil-revoke',
+    'role-create',
+    'role-delete',
+    'place-update',
+    'place-create',
+    'place-delete',
+    'profile-update'
+  ];
+  const now = new Date();
+  const dates = {
+    all: '2019-07-31',
+    week: format(startOfWeek(now), 'YYYY-MM-DD'),
+    month: format(startOfMonth(now), 'YYYY-MM-DD'),
+    year: format(startOfYear(now), 'YYYY-MM-DD')
+  }
+  const counts = countBy(metrics, 'type');
+  const pplApplications = metrics.filter(m => m.type === 'project-application');
+  const iterations = pplApplications
+    .map(m => m.iterations)
+    .reduce((sum, i) => sum + i, 0);
+  const meanIterations = pplApplications.length ? iterations / pplApplications.length : '-';
+
+  return <Fragment>
+
+    <Header title="Performance metrics"/>
 
     <div className="govuk-grid-row">
-      <div className="govuk-grid-column-full">
-        <h2>NTS Summaries</h2>
-        <p><a href="/reporting/2017" className="govuk-button">2017</a></p>
-        <p><a href="/reporting/2018" className="govuk-button">2018</a></p>
+      <div className="govuk-grid-column-one-half">
+        <Metric number={metrics.length} label="total tasks completed" />
+      </div>
+      <div className="govuk-grid-column-one-half">
+        <Metric number={meanIterations} label="mean iterations per PPL application" />
       </div>
     </div>
 
-  </Fragment>
-);
+    <h3>Tasks completed by type:</h3>
 
-export default Index;
+    <div className="govuk-grid-row">
+      <div className="govuk-grid-column-full">
+        <table className="govuk-table">
+          <tbody>
+            {
+              types.map(type => {
+                return <tr key={type}>
+                  <td><Snippet>{ type }</Snippet></td>
+                  <td>{ counts[type] || '0' }</td>
+                </tr>;
+              })
+            }
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div className="link-filter">
+      <label>Showing data for period:</label>
+      <ul>
+        {
+          Object.keys(dates).map(date => {
+            return dates[date] === since ?
+              <li key={date}><strong><Snippet>{ `date.${date}` }</Snippet></strong></li> :
+              <li key={date}><a href={`?since=${dates[date]}`}><Snippet>{ `date.${date}` }</Snippet></a></li>
+          })
+        }
+      </ul>
+    </div>
+
+  </Fragment>
+};
+
+export default connect(({ static: { metrics, since } }) => ({ metrics, since }))(Index);


### PR DESCRIPTION
Adds output for a couple of headline figures and a breakdown of completed tasks by type for a specified date range.

Remove the UI for NTS summaries as that was a bit of a spike, but leave the rendering code in place.