### PR TITLE
Add mean processing time to performance dashboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "express": "^4.16.4",
     "filenamify": "^4.0.0",
     "lodash": "^4.17.15",
+    "moment-business-time": "^0.7.1",
     "react": "^16.9.0",
     "react-redux": "^7.1.0"
   },

--- a/pages/reporting/index.js
+++ b/pages/reporting/index.js
@@ -2,6 +2,7 @@ const { page } = require('@asl/service/ui');
 const archiver = require('archiver');
 const { get } = require('lodash');
 const filenamify = require('filenamify');
+const moment = require('moment-business-time');
 
 const nts = require('./lib/nts-summary');
 
@@ -58,7 +59,12 @@ module.exports = settings => {
     req.api(`/metrics?since=${since}`)
       .then(response => {
         res.locals.static.since = since;
-        res.locals.static.metrics = response.json;
+        res.locals.static.metrics = response.json.map(metric => {
+          return {
+            ...metric,
+            processing: moment(metric.closed).workingDiff(metric.opened, 'hours', true)
+          };
+        });
         next();
       })
       .catch(next);


### PR DESCRIPTION
Adds a mean processing time across all tasks and also on a per-task-type basis.