### PR TITLE
Fix "all" metrics cut-off date

### DIFF
--- a/pages/reporting/views/index.jsx
+++ b/pages/reporting/views/index.jsx
@@ -29,7 +29,7 @@ const Index = ({ metrics, since }) => {
   ];
   const now = new Date();
   const dates = {
-    all: '2019-07-31',
+    all: '2019-01-01',
     week: format(startOfWeek(now), 'YYYY-MM-DD'),
     month: format(startOfMonth(now), 'YYYY-MM-DD'),
     year: format(startOfYear(now), 'YYYY-MM-DD')


### PR DESCRIPTION
I was a little out when I set the dawn of time to 31st July 2019. There is one task that misses the cut.

Instead set the dawn of time to 1st January 2019.