### PR TITLE
Allow removal of all ASRU roles

### DIFF
--- a/pages/profile/components/manage-roles.jsx
+++ b/pages/profile/components/manage-roles.jsx
@@ -38,6 +38,7 @@ class ManageRoles extends React.Component {
 
     return <Fragment>
       <form action="" method="post">
+        <input type="hidden" name="roles" value="" />
         <CheckboxGroup label={ <Snippet>asru.roles.title</Snippet> } name="roles" options={options} value={userRoles} />
         <ControlBar>
           <Button type="submit"><Snippet>asru.roles.save</Snippet></Button>

--- a/pages/profile/index.js
+++ b/pages/profile/index.js
@@ -19,7 +19,7 @@ module.exports = settings => {
 
   app.post('/', (req, res, next) => {
     let data;
-    if (req.body.roles) {
+    if (req.body.roles !== undefined) {
       data = roles.reduce((map, role) => {
         return { ...map, [role]: req.body.roles.includes(role) };
       }, {});


### PR DESCRIPTION
If no roles are selected then the body is empty and nothing is saved. Add a hidden field to the form so that the roles property is always set on the body and the payload is always sent.