### PR TITLE
Use same event key for internal and external error events

### DIFF
--- a/config.js
+++ b/config.js
@@ -16,7 +16,7 @@ module.exports = {
     profile: process.env.API_URL,
     permissions: process.env.PERMISSIONS_SERVICE
   },
-  errorEvent: 'asl-internal.error',
+  errorEvent: 'asl.error',
   verboseErrors: process.env.VERBOSE_ERRORS === 'TRUE',
   pdfService: process.env.PDF_SERVICE
 };


### PR DESCRIPTION
It's easier to use the same event name and then segment by service name in sysdig.