### PR TITLE
Bugfix - fix redirect on est create cancel

### DIFF
--- a/pages/create-establishment/index.js
+++ b/pages/create-establishment/index.js
@@ -19,7 +19,7 @@ module.exports = settings => {
     schema,
     cancelEdit: (req, res, next) => {
       delete req.session.form[req.model.id];
-      return res.redirect(req.buildRoute('establishment.search'));
+      return res.redirect(req.buildRoute('search'));
     }
   }));
 


### PR DESCRIPTION
* We were redirecting to establishment.search, however the path is search which defaults to est