### PR TITLE
Re-order footer links

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -57,9 +57,9 @@ module.exports = settings => {
 
   app.use((req, res, next) => {
     res.locals.footerLinks = [
-      { label: 'Licence fees', href: '/licence-fees' },
       { label: 'Privacy notice', href: '/privacy' },
-      { label: 'Performance metrics', href: '/reporting' }
+      { label: 'Performance metrics', href: '/reporting' },
+      { label: 'Licence fees', href: '/licence-fees' }
     ];
     next();
   });


### PR DESCRIPTION
Privacy notice didn't seem to make sense to me between the billing and performance links, so re-order them so Privacy is first, then functional things are together.