### PR TITLE
Fix CSV exports of search results tables

### DIFF
--- a/pages/search/schema/establishments.js
+++ b/pages/search/schema/establishments.js
@@ -14,7 +14,7 @@ module.exports = {
   inspector: {
     show: true,
     sortable: false,
-    toCSVString: establishment => {
+    toCSVString: (val, establishment) => {
       return establishment.asru
         .filter(p => p.asruInspector)
         .map(profile => `${profile.firstName} ${profile.lastName}`)
@@ -24,7 +24,7 @@ module.exports = {
   spoc: {
     show: true,
     sortable: false,
-    toCSVString: establishment => {
+    toCSVString: (val, establishment) => {
       return establishment.asru
         .filter(p => p.asruLicensing)
         .map(profile => `${profile.firstName} ${profile.lastName}`)

--- a/pages/search/schema/profiles.js
+++ b/pages/search/schema/profiles.js
@@ -6,10 +6,10 @@ module.exports = {
   email: {
     show: true
   },
-  phone: {},
+  telephone: {},
   establishments: {
     show: true,
     sortable: false,
-    toCSVString: row => row.establishments.map(e => e.name).join(', ')
+    toCSVString: (val, row) => row.establishments.map(e => e.name).join(', ')
   }
 };

--- a/pages/search/schema/projects.js
+++ b/pages/search/schema/projects.js
@@ -5,13 +5,13 @@ module.exports = {
   establishment: {
     show: true,
     sort: 'establishment.name',
-    toCSVString: row => row.establishment.name
+    toCSVString: (val, row) => row.establishment.name
   },
   licenceNumber: {},
   licenceHolder: {
     show: true,
     sort: 'licenceHolder.lastName',
-    toCSVString: row => `${row.licenceHolder.firstName} ${row.licenceHolder.lastName}`
+    toCSVString: (val, row) => `${row.licenceHolder.firstName} ${row.licenceHolder.lastName}`
   },
   status: {
     show: true


### PR DESCRIPTION
The `toCSVString` functions had the wrong arguments and so were throwing errors on export to CSV. Correct the arguments to `(value, row)`.