### PR TITLE
Skip API request for global billing metadata if XHR request detected

### DIFF
--- a/pages/licence-fees/index.js
+++ b/pages/licence-fees/index.js
@@ -20,6 +20,10 @@ module.exports = () => {
   });
 
   app.use('/:year', (req, res, next) => {
+    // skip this request if it's an XHR request for table data
+    if (req.get('accept') === 'application/json') {
+      return next();
+    }
     const query = { year: req.year };
     Promise.resolve()
       .then(() => req.api('/billing', { query }))


### PR DESCRIPTION
If all the request is asking for is a new set of table data via XHR then don't make the additional API request to get the global totals as they will not be used.