### PR TITLE
Use all content from tasklist page

### DIFF
--- a/pages/profile/content/index.js
+++ b/pages/profile/content/index.js
@@ -1,12 +1,9 @@
 const { merge } = require('lodash');
 const profileContent = require('@asl/pages/pages/profile/read/content');
 const pilContent = require('@asl/pages/pages/task/read/content/pil');
-const statusContent = require('@asl/pages/pages/task/content/status');
-const tasksContent = require('@asl/pages/pages/task/content/tasks');
+const tasklistContent = require('@asl/pages/pages/task/list/content');
 
-module.exports = merge({}, pilContent, profileContent, {
-  status: statusContent,
-  tasks: tasksContent,
+module.exports = merge({}, pilContent, profileContent, tasklistContent, {
   establishment: {
     link: 'About this establishment'
   },
@@ -32,23 +29,6 @@ module.exports = merge({}, pilContent, profileContent, {
   pil: {
     training: {
       title: 'Training'
-    }
-  },
-  fields: {
-    updatedAt: {
-      label: 'Updated'
-    },
-    establishment: {
-      label: 'Establishment'
-    },
-    licence: {
-      label: 'Licence'
-    },
-    type: {
-      label: 'Type'
-    },
-    status: {
-      label: 'Status'
     }
   }
 });


### PR DESCRIPTION
There are some extra content fields defined in the task list content file that are useful when rendering task lists in profiles - specifically the extension to the deadline passed text. There's also some duplication.

Use all of the task list content in profile task lists.