### PR TITLE
Fix typo in NTS download page

### DIFF
--- a/pages/nts/content/index.js
+++ b/pages/nts/content/index.js
@@ -2,11 +2,11 @@ module.exports = {
   page: {
     title: 'Download non-technical summaries by year',
     subTitle: 'Non-technical summaries',
-    summary: `These will download as a .zip folder containing the PDFs of the non-technical summaries.`
+    summary: `These will download as a .zip folder containing the non-technical summaries.`
   },
   nts: {
     link: {
-      label: 'Non-techincal summaries published in {{year}} (.zip)'
+      label: 'Non-technical summaries published in {{year}} (.zip)'
     }
   }
 };


### PR DESCRIPTION
Also remove the incorrect bit about them being PDFs, because they're not PDFs.