### PR TITLE
Remember search term when moving between model types

### DIFF
--- a/pages/components/search-panel/index.jsx
+++ b/pages/components/search-panel/index.jsx
@@ -1,11 +1,12 @@
 import React, { Component } from 'react';
+import { stringify } from 'qs';
 import { Search, Snippet } from '@asl/components';
 
 class SearchPanel extends Component {
   render() {
     const searchableModels = this.props.searchableModels;
     const searchType = this.props.searchType || searchableModels[0];
-
+    const query = stringify({ filters: this.props.searchTerm });
     return (
       <div className="search-panel">
         <h2><Snippet>searchPanel.title</Snippet></h2>
@@ -13,7 +14,7 @@ class SearchPanel extends Component {
         <ul className="search-type">
           { searchableModels.map(model => (
             <li key={model}>
-              <a href={`/search/${model}`} className={searchType === model ? 'active' : ''}>
+              <a href={`/search/${model}?${query}`} className={searchType === model ? 'active' : ''}>
                 <Snippet>{`searchPanel.${model}.label`}</Snippet>
               </a>
             </li>

--- a/pages/search/views/index.jsx
+++ b/pages/search/views/index.jsx
@@ -83,14 +83,14 @@ const formatters = {
   }
 };
 
-const Index = ({ profile, searchType, searchableModels, hasFilters }) => {
+const Index = ({ profile, searchType, searchableModels, searchTerm, hasFilters }) => {
   return (
     <Fragment>
       <Header title={<Snippet name={profile.firstName}>pages.dashboard.greeting</Snippet>} />
 
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-full">
-          <SearchPanel searchType={searchType} searchableModels={searchableModels} />
+          <SearchPanel searchType={searchType} searchableModels={searchableModels} searchTerm={searchTerm} />
           {
             hasFilters && <LinkFilter
               prop="status"
@@ -116,7 +116,7 @@ const Index = ({ profile, searchType, searchableModels, hasFilters }) => {
 
 const mapStateToProps = ({
   static: { profile, searchType, searchableModels },
-  datatable: { filters: { options } }
-}) => ({ profile, searchType, searchableModels, hasFilters: !!options.length });
+  datatable: { filters: { options, active } }
+}) => ({ profile, searchType, searchableModels, hasFilters: !!options.length, searchTerm: active });
 
 export default connect(mapStateToProps)(Index);


### PR DESCRIPTION
If a person has searched for a type of thing, remember their query if they move between different model types.