### PR TITLE
Default allowed actions to an array

### DIFF
--- a/pages/profile/index.js
+++ b/pages/profile/index.js
@@ -18,7 +18,7 @@ module.exports = settings => {
     res.locals.static.canAdmin = req.user.profile.asruAdmin && req.profileId !== req.user.profile.id;
 
     if (!process.env.ENABLE_PPL_CONVERSION) {
-      res.locals.static.allowedActions = res.locals.static.allowedActions.filter(action => action !== 'project.convertLegacy');
+      res.locals.static.allowedActions = (res.locals.static.allowedActions || []).filter(action => action !== 'project.convertLegacy');
     }
 
     next();


### PR DESCRIPTION
The allowed actions isn't always set at this point if passing through to a child route (it's handled downstream), so trying to filter it results in an error if routing to the downstream router.