### PR TITLE
Add routing for API driven report downloads

### DIFF
--- a/pages/downloads/index.js
+++ b/pages/downloads/index.js
@@ -1,4 +1,5 @@
 const { page } = require('@asl/service/ui');
+const routes = require('./routes');
 
 module.exports = settings => {
   const app = page({
@@ -10,3 +11,5 @@ module.exports = settings => {
 
   return app;
 };
+
+module.exports.routes = routes;

--- a/pages/downloads/reports/index.js
+++ b/pages/downloads/reports/index.js
@@ -1,0 +1,23 @@
+const { Router } = require('express');
+const csv = require('csv-stringify');
+
+module.exports = settings => {
+  const router = Router({ mergeParams: true });
+
+  router.get('/', (req, res, next) => {
+    const report = req.params.report;
+    req.api(`/reports/${report}`)
+      .then(result => {
+        const stringifier = csv({ header: true });
+        res.attachment(`${report}.csv`);
+
+        result.json.data.forEach(row => stringifier.write(row));
+
+        stringifier.pipe(res);
+        return stringifier.end();
+      })
+      .catch(next);
+  });
+
+  return router;
+};

--- a/pages/downloads/routes.js
+++ b/pages/downloads/routes.js
@@ -1,0 +1,9 @@
+const report = require('./reports');
+
+module.exports = {
+  'report': {
+    path: '/:report',
+    router: report,
+    breadcrumb: false
+  }
+};

--- a/pages/downloads/views/index.jsx
+++ b/pages/downloads/views/index.jsx
@@ -7,10 +7,17 @@ const Index = () => {
     <Header title="Downloads"/>
 
     <h2>General downloads</h2>
+
     <p><Link page="reporting" query={{ csv: 1 }} label="Completed tasks" /></p>
     <p>View a list of all completed tasks by type, which will be downloadable in a .csv file.</p>
 
+    <h2>Personal licence downloads</h2>
+
+    <p><Link page="downloads.report" report="pil-reviews" label="Upcoming PIL reviews" /></p>
+    <p>View a list of PILs which are due a review, which will be downloadable in a .csv file.</p>
+
     <h2>Project licence downloads</h2>
+
     <p><Link page="nts" label="Non-technical summaries by year" /></p>
     <p>View a list of all non-technical summaries by year, which will be downloadable in a .zip file.</p>
   </Fragment>


### PR DESCRIPTION
Map routes under `/downloads/:report` to API endpoints in the internal API and output whatever data is returned by the API endpoint as a CSV file.

Implement first report as `/downloads/pil-review`