### PR TITLE
Fix NTS fate key in NTS bulk downloads

### DIFF
--- a/pages/nts/lib/renderers/v1.js
+++ b/pages/nts/lib/renderers/v1.js
@@ -129,7 +129,7 @@ const render = (doc, project) => {
 
   table.getRow(++row).mergeCells(1, 2);
   table.getCell(row, 0).addParagraph(new Paragraph('What will happen to animals at the end of this project?').style('body'));
-  table.getCell(row, 1).addParagraph(new Paragraph((project.data['fate-of-animals-nts'] || []).join(', ')).style('body'));
+  table.getCell(row, 1).addParagraph(new Paragraph((project.data['fate-of-animals'] || []).join(', ')).style('body'));
 
   table.getRow(++row).mergeCells(1, 2);
   table.getCell(row, 0).addParagraph(new Paragraph('Why do you need to use animals to achieve the aim of your project?').style('body'));


### PR DESCRIPTION
The key no longer has `-nts` on it. Remove that in the bulk NTS download renderer.