### PR TITLE
"Handle" images nested inside table cells

### DIFF
--- a/pages/nts/lib/rich-text.js
+++ b/pages/nts/lib/rich-text.js
@@ -229,7 +229,17 @@ const renderTextEditor = (doc, value) => {
         break;
 
       case 'image':
-        doc.createImage(node.data.src, node.data.width, node.data.height);
+        try {
+          doc.createImage(node.data.src, node.data.width, node.data.height);
+        } catch (e) {
+          // `doc.createImage` sometimes fails if it's nested in certain ways
+          // the fix is complex, and this feature is short-lived so fail better instead
+          const p = new Paragraph();
+          const t = new TextRun('[IMAGE RENDER FAILED]');
+          p.style('body');
+          p.addRun(t);
+          doc.addParagraph(p);
+        }
         break;
 
       default:


### PR DESCRIPTION
Images nested inside table cells fail the entire document with an error. This was fixed for the full application download, but the fix is complex, so for this context (and the literally one PPL it applies to) just fail with an inline error message and allow the rest of the content to render.