### PR TITLE
Some hacks to make one renderer work with both upstream data sources

### DIFF
--- a/pages/nts-experimental/index.js
+++ b/pages/nts-experimental/index.js
@@ -21,10 +21,11 @@ module.exports = settings => {
     archive.pipe(res);
 
     const writeFile = (project, encoding, callback) => {
+      project.project = { schemaVersion: project.schema_version, title: project.title };
       return Promise.resolve()
         .then(() => nts(project))
         .then(doc => {
-          const fileName = `${project.isLegacyStub ? `STUB-` : ''}${filenamify(project.title)}-${project.id}.docx`;
+          const fileName = `${project.is_legacy_stub ? `STUB-` : ''}${filenamify(project.title)}-${project.id}.docx`;
           return archive.append(Buffer.from(doc), { name: fileName });
         })
         .catch(e => {


### PR DESCRIPTION
These will be removed once it's consolidated, but are necessary now to avoid repeating the entire renderer.