### PR TITLE
Bugfix - related tasks.

### DIFF
--- a/pages/global-profile/views/index.jsx
+++ b/pages/global-profile/views/index.jsx
@@ -43,7 +43,9 @@ export default function InternalGlobalProfile() {
           <AsruAssociations establishments={model.asru} />
         </Fragment>
       }
-      <RelatedTasks />
+      {
+        model.asruUser && <RelatedTasks />
+      }
     </GlobalProfile>
   )
 }


### PR DESCRIPTION
For non asru users, the related tasks component is rendered by the global profile in pages, it should only be added here if the model is a asru user