### PR TITLE
Add a header if experimental search is enabled

### DIFF
--- a/pages/search/index.js
+++ b/pages/search/index.js
@@ -10,6 +10,13 @@ module.exports = () => {
     next();
   });
 
+  app.use((req, res, next) => {
+    if (req.query.experimental) {
+      req.session.experimentalSearch = req.query.experimental === 'true';
+    }
+    next();
+  });
+
   app.use('/:searchType', search());
   app.use('/', search());
 

--- a/pages/search/search.js
+++ b/pages/search/search.js
@@ -34,6 +34,9 @@ module.exports = settings => {
       req.datatable.searchType = searchType;
       req.datatable.schema = schemas[searchType];
       req.datatable.apiPath = `/search/${searchType}`;
+      if (req.session.experimentalSearch) {
+        req.datatable.apiPath = [`/search/${searchType}`, { headers: { 'x-experimental-search': true } }];
+      }
       next();
     }
   })());


### PR DESCRIPTION
This allows us to hit the same API endpoint, but with a flag to set experimental search if enabled on the downstream service.

Used a header rather than a querystring param because it is guaranteed not to interfere with the existing params in that case. It also is safer when deploying into environments without experimental search enabled than a separate endpoint.