### PR TITLE
Re-order mounting profile routers

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -66,15 +66,15 @@ module.exports = {
     router: revokeEstablishment,
     permissions: 'establishment.revoke'
   },
-  training: {
-    path: '/establishments/:establishmentId/people/:profileId/training',
-    breadcrumb: false,
-    router: pages.training
-  },
   profile: {
     path: '/establishments/:establishmentId/people',
     breadcrumb: false,
     router: pages.profile
+  },
+  training: {
+    path: '/establishments/:establishmentId/people/:profileId/training',
+    breadcrumb: false,
+    router: pages.training
   },
   role: {
     path: '/establishments/:establishmentId/people/:profileId/role',

--- a/package-lock.json
+++ b/package-lock.json
@@ -172,9 +172,9 @@
       }
     },
     "@asl/service": {
-      "version": "8.1.2",
-      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/service/-/@asl/service-8.1.2.tgz",
-      "integrity": "sha1-8owP7ogvOAZX53eLFkiGO9aCEEI=",
+      "version": "8.1.3",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/service/-/@asl/service-8.1.3.tgz",
+      "integrity": "sha1-x6Xbn+Abow+nSTtzv3CQPljO6W4=",
       "requires": {
         "@asl/components": "^8.0.0",
         "@babel/core": "^7.4.4",
@@ -4485,11 +4485,11 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "ms": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@asl/components": "^8.5.9",
     "@asl/pages": "^23.2.2",
     "@asl/projects": "^8.0.1",
-    "@asl/service": "^8.1.2",
+    "@asl/service": "^8.1.3",
     "@babel/core": "^7.6.2",
     "@babel/plugin-proposal-object-rest-spread": "^7.6.2",
     "@babel/preset-env": "^7.6.2",


### PR DESCRIPTION
Need to mount the generic profile router first to ensure that req.profile is available downstream.