### PR TITLE
Reset sort and query string parameters when performing a new search

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@asl/components": {
-      "version": "8.5.9",
-      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/components/-/@asl/components-8.5.9.tgz",
-      "integrity": "sha1-H1v2XWqkqi7gnxAhOIVBm+kqvNw=",
+      "version": "8.5.11",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/components/-/@asl/components-8.5.11.tgz",
+      "integrity": "sha1-J9GFWybcKpJ7r41EgvMM53IhRms=",
       "requires": {
         "@asl/dictionary": "^1.1.5",
         "@ukhomeoffice/react-components": "^0.8.5",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/UKHomeOffice/asl-internal-ui#readme",
   "dependencies": {
-    "@asl/components": "^8.5.9",
+    "@asl/components": "^8.5.11",
     "@asl/pages": "^23.2.2",
     "@asl/projects": "^8.0.2",
     "@asl/service": "^8.1.3",

--- a/pages/components/search-panel/index.jsx
+++ b/pages/components/search-panel/index.jsx
@@ -33,7 +33,7 @@ class SearchPanel extends Component {
 
         <div className="govuk-grid-row">
           <div className="govuk-grid-column-two-thirds">
-            <Search action={this.props.action} name="filter-*" labelledBy="search-title" />
+            <Search action={this.props.action} name="filter-*" labelledBy="search-title" query={{ sort: null, page: 1 }} />
           </div>
 
           <div className="govuk-grid-column-one-third">


### PR DESCRIPTION
If submitting a new search then remove any sort and pagination from the query string and revert to page 1 sorted by the default sort order.

This is specifically pertinent if the sort parameters have been inherited from a tasklist on the dashboard, and refer to sort columns and pages that don't exist.