### PR TITLE
Various fixes for deadline management

### DIFF
--- a/pages/reporting/details/ppl-sla/content/index.js
+++ b/pages/reporting/details/ppl-sla/content/index.js
@@ -8,14 +8,11 @@ module.exports = {
     notExempt: 'Deadlines missed'
   },
   fields: {
-    deadlineDate: {
+    deadlinePassedDate: {
       label: 'Statutory deadline'
     },
     projectTitle: {
       label: 'Project title'
-    },
-    daysOverdue: {
-      label: 'Days overdue'
     },
     isExempt: {
       label: 'Deadline status'

--- a/pages/reporting/details/ppl-sla/index.js
+++ b/pages/reporting/details/ppl-sla/index.js
@@ -13,7 +13,7 @@ module.exports = settings => {
 
   app.get('/', datatable({
     configure: (req, res, next) => {
-      req.datatable.sort = { column: 'deadlineDate', ascending: true };
+      req.datatable.sort = { column: 'deadlinePassedDate', ascending: true };
       next();
     },
     getApiPath: (req, res, next) => {

--- a/pages/reporting/details/ppl-sla/schema/index.js
+++ b/pages/reporting/details/ppl-sla/schema/index.js
@@ -1,13 +1,9 @@
 module.exports = {
-  deadlineDate: {
+  deadlinePassedDate: {
     show: true,
     sortable: false
   },
   projectTitle: {
-    show: true,
-    sortable: false
-  },
-  daysOverdue: {
     show: true,
     sortable: false
   },

--- a/pages/reporting/details/ppl-sla/views/formatters.jsx
+++ b/pages/reporting/details/ppl-sla/views/formatters.jsx
@@ -8,7 +8,9 @@ export default {
     format: val => format(val, dateFormat.medium)
   },
   projectTitle: {
-    format: (title, model) => <Link page="project.read" establishmentId={model.establishmentId} projectId={model.projectId} label={title} />
+    format: (title, task) => (
+      <Link page="project.read" establishmentId={task.data.modelData.establishmentId} projectId={task.data.modelData.id} label={title} />
+    )
   },
   isExempt: {
     format: val => val === true ? <label className="badge blue">Not missed</label> : <label className="badge">Missed</label>

--- a/pages/reporting/details/ppl-sla/views/formatters.jsx
+++ b/pages/reporting/details/ppl-sla/views/formatters.jsx
@@ -4,7 +4,7 @@ import { dateFormat } from '@asl/pages/constants';
 import { Link } from '@asl/components';
 
 export default {
-  deadlineDate: {
+  deadlinePassedDate: {
     format: val => format(val, dateFormat.medium)
   },
   projectTitle: {


### PR DESCRIPTION
 * deadlineDate (from deadline object) was removed in favour of deadlinePassedDate which stays set if the task is returned
 * daysOverdue was removed because the calculation is not as simple as days before now