### PR TITLE
Preserve decimal places on metric numbers less than 1000

### DIFF
--- a/pages/reporting/views/components/number.jsx
+++ b/pages/reporting/views/components/number.jsx
@@ -5,7 +5,7 @@ const format = number => {
     return '-';
   }
   if (number !== Math.floor(number) && number < 1000) {
-    number = number.toFixed(2);
+    return number.toFixed(2);
   }
   return Math.floor(number).toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
 };


### PR DESCRIPTION
The code to insert commas into large numbers was removing the decimal places from the iterations count, where we need the exact value.