### PR TITLE
Add "hidden" page for full-content PPL search

### DIFF
--- a/assets/sass/app.scss
+++ b/assets/sass/app.scss
@@ -73,6 +73,13 @@ td .govuk-button {
   th.numeric, td.numeric {
     text-align: right;
   }
+
+  .search-highlight {
+    strong {
+      @extend .highlight;
+      font-weight: normal;
+    }
+  }
 }
 
 .metric {

--- a/pages/components/search-panel/content.js
+++ b/pages/components/search-panel/content.js
@@ -14,5 +14,9 @@ module.exports = {
     title: 'Projects',
     label: 'Search by name or licence number',
     viewAll: 'View all active projects'
+  },
+  'projects-content': {
+    title: 'Project Content',
+    label: 'Search full application text'
   }
 };

--- a/pages/components/search-panel/index.jsx
+++ b/pages/components/search-panel/index.jsx
@@ -29,14 +29,15 @@ export default function SearchPanel(props) {
             query={{ sort: null, page: 1 }}
           />
         </div>
-
-        <div className="govuk-grid-column-one-third">
-          <div className="view-all-link">
-            <a href={`/search/${searchType}?${searchableModels.find(m => m.name === searchType).query}`}>
-              <Snippet>{`searchPanel.${searchType}.viewAll`}</Snippet>
-            </a>
+        {
+          (searchType !== 'projects-content') && <div className="govuk-grid-column-one-third">
+            <div className="view-all-link">
+              <a href={`/search/${searchType}?${searchableModels.find(m => m.name === searchType).query}`}>
+                <Snippet>{`searchPanel.${searchType}.viewAll`}</Snippet>
+              </a>
+            </div>
           </div>
-        </div>
+        }
       </div>
     </Fragment>
   );

--- a/pages/search/content/index.js
+++ b/pages/search/content/index.js
@@ -3,6 +3,7 @@ const establishments = require('./establishments');
 const profiles = require('./profiles');
 const baseProjects = require('@asl/pages/pages/project/content');
 const projects = require('./projects');
+const projectsContent = require('./projects-content');
 
 const models = {
   establishments,
@@ -10,7 +11,8 @@ const models = {
   projects: {
     ...baseProjects,
     ...projects
-  }
+  },
+  'projects-content': projectsContent
 };
 
 module.exports = (searchType) => ({

--- a/pages/search/content/projects-content.js
+++ b/pages/search/content/projects-content.js
@@ -1,0 +1,55 @@
+module.exports = {
+  pageTitle: 'Search projects',
+  fields: {
+    title: {
+      label: ''
+    }
+  },
+  sections: {
+    introduction: 'Introductory details',
+    aims: 'Aims',
+    benefits: 'Benefits',
+    'project-harms': 'Project harms',
+    'fate-of-animals': 'Fate of animals',
+    replacement: 'Replacement',
+    reduction: 'Reduction',
+    refinement: 'Refinement',
+    experience: 'Experience',
+    funding: 'Funding',
+    establishments: 'Establishments',
+    'transfer-of-animals': 'Transfer of animals',
+    poles: 'Places other than a licensed establishment (POLEs)',
+    'scientific-background': 'Scientific background',
+    'training-background': 'Scientific background',
+    'action-plan': 'Action plan',
+    'general-principles': 'General principles',
+    protocols: 'Protocol - {{protocol}}',
+    domestic: 'Cats, dogs, and equidae',
+    nhps: 'Non-human primates',
+    'purpose-bred-animals': 'Purpose bred animals',
+    'endangered-animals': 'Endangered animals',
+    'animals-taken-from-the-wild': 'Animals taken from the wild',
+    'feral-animals': 'Feral animals',
+    nmbas: 'Neuromuscular blocking agents (NMBAs)',
+    'reusing-animals': 'Re-using animals',
+    'commercial-slaughter': 'Comercial slaughter',
+    'comtaining-human-material': 'Animals containing human material',
+    'keeping-alive': 'Keeping animals alive',
+    'setting-free': 'Setting animals free',
+    rehoming: 'Rehoming animals',
+    // legacy sections
+    resources: 'Resources',
+    background: 'Background',
+    references: 'References',
+    purpose: 'Purpose',
+    plan: 'Project plan',
+    origin: 'Origin',
+    endangered: 'Endangered animals',
+    wild: 'Animals taken from the wild',
+    marmosets: 'Marmosets',
+    summary: 'Project summary',
+    'nts-replacement': 'Replacement',
+    'nts-reduction': 'Reduction',
+    'nts-refinement': 'Refinement'
+  }
+};

--- a/pages/search/index.js
+++ b/pages/search/index.js
@@ -5,7 +5,7 @@ const schemas = require('./schema');
 const NotFoundError = require('../../lib/errors/not-found');
 const content = require('./content');
 
-const searchableModels = ['establishments', 'profiles', 'projects'];
+const searchableModels = ['establishments', 'profiles', 'projects', 'projects-content'];
 
 module.exports = settings => {
   const app = page({
@@ -34,9 +34,6 @@ module.exports = settings => {
       req.datatable.searchType = searchType;
       req.datatable.schema = schemas[searchType];
       req.datatable.apiPath = `/search/${searchType}`;
-      if (req.session.experimentalSearch) {
-        req.datatable.apiPath = [`/search/${searchType}`, { headers: { 'x-experimental-search': true } }];
-      }
       next();
     }
   })());

--- a/pages/search/schema/index.js
+++ b/pages/search/schema/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   establishments: require('./establishments'),
   profiles: require('./profiles'),
-  projects: require('./projects')
+  projects: require('./projects'),
+  'projects-content': require('./projects-content')
 };

--- a/pages/search/schema/projects-content.js
+++ b/pages/search/schema/projects-content.js
@@ -1,0 +1,6 @@
+module.exports = {
+  title: {
+    show: true,
+    sortable: false
+  }
+};

--- a/pages/search/views/components/project-search-result.jsx
+++ b/pages/search/views/components/project-search-result.jsx
@@ -1,0 +1,64 @@
+import React, { Fragment, useState } from 'react';
+import {
+  Link,
+  Markdown,
+  Snippet,
+  Inset
+} from '@asl/components';
+
+const Highlight = ({ project, highlight, field }) => {
+  const section = field.split('.')[1];
+  let protocol = {};
+  if (section === 'protocols') {
+    const protocolId = field.split('.')[2];
+    protocol = project.protocols.find(p => p.id === protocolId);
+  }
+  return <Fragment>
+    <h4><Snippet protocol={protocol.title}>{`sections.${section}`}</Snippet></h4>
+    <Inset className="search-highlight">
+      <Markdown>{ `...${highlight[0].trim()}...` }</Markdown>
+    </Inset>
+  </Fragment>;
+};
+
+const ProjectSearchResult = ({ project }) => {
+  const [expanded, setExpanded] = useState(false);
+  const highlights = Object.keys(project.highlight || {});
+  const hasMore = highlights.length > 1;
+
+  const toggle = (e) => {
+    e.preventDefault();
+    setExpanded(!expanded);
+  };
+
+  return (
+    <Fragment>
+      <h3>
+        <Link
+          page="projectVersion"
+          establishmentId={project.establishment.id}
+          projectId={project.id}
+          versionId={project.versionId}
+          label={project.title || 'Untitled project'}
+        />
+      </h3>
+
+      {
+        highlights.map((key, i) => {
+          if (i > 0 && !expanded) {
+            return null;
+          }
+          const highlight = project.highlight[key];
+          return <Highlight project={project} highlight={highlight} field={key} key={key} />;
+        })
+      }
+      {
+        hasMore && (
+          <p><a href="#" onClick={toggle}>{ expanded ? 'Show fewer matches in this project' : `Show ${highlights.length - 1} more matches in this project` }</a></p>
+        )
+      }
+    </Fragment>
+  );
+};
+
+export default ProjectSearchResult;

--- a/pages/search/views/index.jsx
+++ b/pages/search/views/index.jsx
@@ -8,12 +8,11 @@ import {
   Header,
   Link,
   Snippet,
-  LinkFilter,
-  Markdown,
-  Inset
+  LinkFilter
 } from '@asl/components';
 import SearchPanel from '../../components/search-panel';
 import DashboardNavigation from '../../components/dashboard-navigation';
+import ProjectSearchResult from './components/project-search-result';
 import { projectTitle } from '@asl/pages/pages/common/formatters';
 import projectFormatters from '@asl/pages/pages/project/formatters';
 
@@ -99,34 +98,7 @@ const formatters = {
   },
   'projects-content': {
     title: {
-      format: (title, project) => {
-        return (
-          <Fragment>
-            <h3><Link
-              page="projectVersion"
-              establishmentId={project.establishment.id}
-              projectId={project.id}
-              versionId={project.versionId}
-              label={projectTitle(project)}
-              /></h3>
-            {
-              Object.keys(project.highlight || {}).map(key => {
-                const highlight = project.highlight[key];
-                const section = key.split('.')[1];
-                let protocol = {};
-                if (section === 'protocols') {
-                  const protocolId = key.split('.')[2];
-                  protocol = project.protocols.find(p => p.id === protocolId);
-                }
-                return <Fragment>
-                  <h4><Snippet protocol={protocol.title}>{`sections.${section}`}</Snippet></h4>
-                  <Inset className="search-highlight">{ highlight.map(line => <Markdown>{ `...${line.trim()}...` }</Markdown>) }</Inset>
-                </Fragment>;
-              })
-            }
-          </Fragment>
-        );
-      }
+      format: (title, project) => <ProjectSearchResult project={project} />
     }
   }
 };


### PR DESCRIPTION
Creates `/search/projects-content` which exposes a UI for full content PPL searching.

This page is not currently linked in the navigation so we can safely deploy an alpha to prod.