### PR TITLE
Add basic project fields to content search schema

### DIFF
--- a/pages/search/schema/projects-content.js
+++ b/pages/search/schema/projects-content.js
@@ -2,5 +2,13 @@ module.exports = {
   title: {
     show: true,
     sortable: false
-  }
+  },
+  establishment: {
+    toCSVString: (val, row) => row.establishment.name
+  },
+  licenceNumber: {},
+  licenceHolder: {
+    toCSVString: (val, row) => `${row.licenceHolder.firstName} ${row.licenceHolder.lastName}`
+  },
+  status: {}
 };


### PR DESCRIPTION
This means that if the datatable of results is exported as a CSV it includes some more useful metadata about the projects that match the query.