### PR TITLE
Remove filter styles which are no longer needed

### DIFF
--- a/assets/sass/app.scss
+++ b/assets/sass/app.scss
@@ -116,15 +116,6 @@ ul.nts-downloads {
     }
   }
 
-  .link-filter {
-    margin: 0;
-  }
-
-  h2.filter-summary {
-    font-weight: normal;
-    font-size: 18px;
-  }
-
   .govuk-table td p {
     margin: 0;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@asl/components": {
-      "version": "8.10.1",
-      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/components/-/@asl/components-8.10.1.tgz",
-      "integrity": "sha1-mT25ioU0Z+BehWOcqyS0k4gu/SA=",
+      "version": "8.10.2",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/components/-/@asl/components-8.10.2.tgz",
+      "integrity": "sha1-5pGvO5Dvlg9aZsYFSRaLfRoocsA=",
       "requires": {
         "@asl/dictionary": "^1.1.5",
         "@ukhomeoffice/react-components": "^0.8.5",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/UKHomeOffice/asl-internal-ui#readme",
   "dependencies": {
-    "@asl/components": "^8.10.1",
+    "@asl/components": "^8.10.2",
     "@asl/pages": "^23.18.1",
     "@asl/projects": "^8.3.11",
     "@asl/service": "^8.6.2",


### PR DESCRIPTION
The margin has been set to zero everywhere, and standard `h3` tags/styles are now used for the summary component.