### PR TITLE
Simplify clear search link

### DIFF
--- a/pages/components/search-panel/content.js
+++ b/pages/components/search-panel/content.js
@@ -1,19 +1,17 @@
 module.exports = {
   title: 'Search',
+  viewAll: 'Clear search',
   establishments: {
     title: 'Establishments',
-    label: 'Search by establishment name, PEL number, inspector name or SPoC name',
-    viewAll: 'Clear search'
+    label: 'Search by establishment name, PEL number, inspector name or SPoC name'
   },
   profiles: {
     title: 'People',
-    label: 'Search by name, email address or PIL number',
-    viewAll: 'Clear search'
+    label: 'Search by name, email address or PIL number'
   },
   projects: {
     title: 'Projects',
-    label: 'Search by title, primary establishment, PPL number or licence holder',
-    viewAll: 'Clear search'
+    label: 'Search by title, primary establishment, PPL number or licence holder'
   },
   'projects-content': {
     title: 'Project Content',

--- a/pages/components/search-panel/index.jsx
+++ b/pages/components/search-panel/index.jsx
@@ -33,7 +33,7 @@ export default function SearchPanel(props) {
           (searchType !== 'projects-content') && <div className="govuk-grid-column-one-third">
             <div className="view-all-link">
               <a href={`/search/${searchType}?${searchableModels.find(m => m.name === searchType).query}`}>
-                <Snippet>{`searchPanel.${searchType}.viewAll`}</Snippet>
+                <Snippet>{`searchPanel.viewAll`}</Snippet>
               </a>
             </div>
           </div>


### PR DESCRIPTION
It's the same text in all cases, so there doesn't seem like much point in defining separately for all search types.