### PR TITLE
Prevent error if no highlights returned

### DIFF
--- a/pages/search/views/components/project-search-result.jsx
+++ b/pages/search/views/components/project-search-result.jsx
@@ -61,7 +61,7 @@ const ProjectSearchResult = ({ project }) => {
   const hasMore = highlights.length > 1;
 
   let title = project.title || 'Untitled project';
-  if (project.highlight.title && project.highlight.title[0]) {
+  if (project.highlight && project.highlight.title && project.highlight.title[0]) {
     title = <Markdown>{ project.highlight.title[0] }</Markdown>;
   }
 


### PR DESCRIPTION
When clearing a null search the order of redux actions means that there's an infinitessimally small window in which results are returned but the search term state is not updated to prevent rendering results when no search term is entered.

This means that results with no highlighted terms are attempted to render, and so throw an error.

Handle the no highlight case to avoid this error.