### PR TITLE
Preserve query string when redirecting metrics filter form

### DIFF
--- a/pages/reporting/index.js
+++ b/pages/reporting/index.js
@@ -59,7 +59,7 @@ module.exports = settings => {
       next();
     },
     saveValues: (req, res) => {
-      res.redirect(req.baseUrl);
+      res.redirect(req.originalUrl);
     }
   }));
 


### PR DESCRIPTION
If a user has selected a non-default tab on the performance metrics page then preserve that on submission of the filters form.