### PR TITLE
Define `sort` param for profile search table

### DIFF
--- a/pages/search/schema/profiles.js
+++ b/pages/search/schema/profiles.js
@@ -1,6 +1,7 @@
 module.exports = {
   name: {
-    show: true
+    show: true,
+    sort: 'lastName'
   },
   email: {
     show: true


### PR DESCRIPTION
The sorting isn't working because the incorrect parameter name is being sent as the sort query when sorting by name. It needs to be `lastName` to match the field name in the data.