### PR TITLE
Add default sorting props to search results

### DIFF
--- a/pages/search/index.js
+++ b/pages/search/index.js
@@ -6,6 +6,11 @@ const NotFoundError = require('../../lib/errors/not-found');
 const content = require('./content');
 
 const searchableModels = ['establishments', 'profiles', 'projects', 'projects-content'];
+const defaultSort = {
+  establishments: 'name',
+  profiles: 'name',
+  projects: 'title'
+};
 
 module.exports = settings => {
   const app = page({
@@ -34,6 +39,9 @@ module.exports = settings => {
       req.datatable.searchType = searchType;
       req.datatable.schema = schemas[searchType];
       req.datatable.apiPath = `/search/${searchType}`;
+      if (defaultSort[searchType]) {
+        req.datatable.sort = { column: defaultSort[searchType], ascending: true };
+      }
       next();
     }
   })());


### PR DESCRIPTION
Currently the first click on the sorting header in a table is a no-op if it matches the default sort order.

By setting the default sort order explicitly then clicking on the name header the first time will reverse the sort order.