### PR TITLE
Don't split RA metrics into legacy and new

### DIFF
--- a/pages/reporting/index.js
+++ b/pages/reporting/index.js
@@ -81,7 +81,7 @@ module.exports = settings => {
             }
 
             let type = `${data.model}-${data.action}`;
-            if (data.model === 'project' && data.schemaVersion === 0) {
+            if (data.model === 'project' && data.action !== 'grant-ra' && data.schemaVersion === 0) {
               type = `legacy-project-${data.action}`;
             }
             tasks[type] = tasks[type] + 1 || 1;


### PR DESCRIPTION
Previously all project tasks on legacy projects were re-mapped to `legacy-project-${action}` which prevented RA tasks for legacy projects showing in the count for `project-grant-ra`.

Prevent mapping these as we don't want to split into new and legacy figures.