### PR TITLE
Don't include blank search term in search summary

### DIFF
--- a/pages/search/content/index.js
+++ b/pages/search/content/index.js
@@ -50,8 +50,8 @@ module.exports = (searchType) => ({
   },
   results: {
     filtered: {
-      singular: 'Showing {{count}} result for: **\'{{searchTerm}}\'**',
-      plural: 'Showing {{count}} results for: **\'{{searchTerm}}\'**'
+      singular: 'Showing {{count}} result{{#searchTerm}} for: **\'{{searchTerm}}\'**{{/searchTerm}}',
+      plural: 'Showing {{count}} results{{#searchTerm}} for: **\'{{searchTerm}}\'**{{/searchTerm}}'
     }
   }
 });


### PR DESCRIPTION
If a filter has been applied but no search term entered then don't show `X results for: ''`.