### PR TITLE
Add global page with details of all PILs for a user

### DIFF
--- a/pages/global-profile/content/index.js
+++ b/pages/global-profile/content/index.js
@@ -29,5 +29,11 @@ module.exports = merge({}, globalProfile, {
       }
     }
   },
+  breadcrumbs: {
+    globalProfile: {
+      read: '{{profile.firstName}} {{profile.lastName}}',
+      pils: 'Personal licences'
+    }
+  },
   dedupe: 'Merge profile'
 });

--- a/pages/global-profile/index.js
+++ b/pages/global-profile/index.js
@@ -1,5 +1,6 @@
 const { page } = require('@asl/service/ui');
 const bodyParser = require('body-parser');
+const routes = require('./routes');
 const { relatedTasks } = require('@asl/pages/pages/common/routers');
 
 const roles = ['asruAdmin', 'asruSupport', 'asruLicensing', 'asruInspector', 'asruRops'];
@@ -10,14 +11,13 @@ module.exports = () => {
   app.use(bodyParser.urlencoded({ extended: true }));
 
   app.use((req, res, next) => {
-    req.breadcrumb('profile.read');
     res.locals.static.roles = roles;
     res.locals.static.canAdmin = req.user.profile.asruAdmin && req.profileId !== req.user.profile.id;
     res.locals.static.asruUser = req.user.profile.asruUser;
     next();
   });
 
-  app.get('/', (req, res, next) => {
+  app.get('*', (req, res, next) => {
     return req.api(`/profile/${req.profileId}`)
       .then(({ json: { data } }) => {
         res.locals.model = data;
@@ -57,3 +57,5 @@ module.exports = () => {
 
   return app;
 };
+
+module.exports.routes = routes;

--- a/pages/global-profile/pils/content/index.js
+++ b/pages/global-profile/pils/content/index.js
@@ -1,0 +1,17 @@
+const { merge } = require('lodash');
+const content = require('../../content');
+const pilContent = require('@asl/pages/pages/pil/read/content');
+
+module.exports = merge({}, content, pilContent, {
+  fields: {
+    pilTransfers: {
+      label: 'Transfer history'
+    },
+    trainingNeed: {
+      label: 'Training need'
+    },
+    project: {
+      label: 'Project'
+    }
+  }
+});

--- a/pages/global-profile/pils/index.js
+++ b/pages/global-profile/pils/index.js
@@ -1,0 +1,17 @@
+const { page } = require('@asl/service/ui');
+
+module.exports = () => {
+  const app = page({ root: __dirname });
+
+  app.get('/', (req, res, next) => {
+    return req.api(`/profile/${req.profileId}/pil`)
+      .then(({ json: { data } }) => {
+        res.locals.model.pils = data.pils;
+        res.locals.model.trainingPils = data.trainingPils;
+      })
+      .then(() => next())
+      .catch(next);
+  });
+
+  return app;
+};

--- a/pages/global-profile/pils/views/index.jsx
+++ b/pages/global-profile/pils/views/index.jsx
@@ -1,0 +1,187 @@
+import React, { Fragment } from 'react';
+import { useSelector } from 'react-redux';
+import classnames from 'classnames';
+import sortBy from 'lodash/sortBy';
+import format from 'date-fns/format';
+import { Conditions, Header, Inset, Link, Markdown, ModelSummary, Snippet } from '@asl/components';
+import schema from '@asl/pages/pages/pil/read/schema';
+
+const getStatusClass = (status) => {
+  switch (status) {
+    case 'active':
+      return 'complete';
+    case 'revoked':
+    case 'expired':
+      return 'rejected';
+  }
+};
+
+const formatDate = date => date ? format(date, 'DD MMMM YYYY') : '-';
+
+const pilSchema = {
+  status: { show: true },
+  ...schema,
+  pilTransfers: { show: true }
+};
+const trainingPilSchema = {
+  status: { show: true },
+  establishment: { show: true, accessor: 'trainingCourse.establishment' },
+  issueDate: { show: true },
+  revocationDate: { show: true },
+  expiryDate: { show: true },
+  species: { show: true, accessor: 'trainingCourse.species' },
+  trainingNeed: { show: true },
+  project: { show: true, accessor: 'trainingCourse.project' }
+};
+
+const formatters = {
+  status: {
+    format: status => <span className={classnames('badge', getStatusClass(status))}>{ status }</span>
+  },
+  issueDate: {
+    format: formatDate
+  },
+  licenceNumber: {},
+  revocationDate: {
+    format: formatDate
+  },
+  reviewDate: {
+    format: formatDate
+  },
+  updatedAt: {
+    format: formatDate
+  },
+  expiryDate: {
+    format: formatDate
+  },
+  establishment: {
+    format: establishment => {
+      return establishment && establishment.name ? <Link page="establishment.read" establishmentId={establishment.id} label={establishment.name} /> : '-';
+    }
+  },
+  species: {
+    format: pilSpecies => {
+      if (!pilSpecies) {
+        return '-';
+      }
+      if (!Array.isArray(pilSpecies)) {
+        return null;
+      }
+
+      return (
+        <ul>
+          { pilSpecies.map(species => <li key={species}>{species}</li>) }
+        </ul>
+      );
+    }
+  },
+  procedures: {
+    format: (procedures, pil) => {
+      if (!procedures || !procedures.length) {
+        return '-';
+      }
+      return <ul>
+        {
+          procedures.map((procedure) => <li key={ procedure }>
+            { procedure }
+            {
+              procedure === 'D' && <Inset><Markdown>{ pil.notesCatD }</Markdown></Inset>
+            }
+            {
+              (procedure === 'E' || procedure === 'F') && <Inset><Markdown>{ pil.notesCatF }</Markdown></Inset>
+            }
+          </li>)
+        }
+      </ul>;
+    }
+  },
+  conditions: {
+    format: conditions => {
+      return (
+        <Conditions
+          conditions={conditions}
+          canUpdate={false}
+          label={<Snippet>conditions.hasConditions</Snippet>}
+          noConditionsLabel={<Snippet>conditions.noConditions</Snippet>}
+        />
+      );
+    }
+  },
+  pilTransfers: {
+    format: transfers => {
+      if (!transfers.length) {
+        return '-';
+      }
+      return <ul>
+        {
+          transfers.map(transfer => {
+            return <li key={transfer.id}>
+              <span>{formatDate(transfer.createdAt)}: </span>
+              <Link page="establishment" establishmentId={transfer.fromEstablishmentId} label={transfer.from.name} />
+              <span> to </span>
+              <Link page="establishment" establishmentId={transfer.toEstablishmentId} label={transfer.to.name} />
+            </li>;
+          })
+        }
+      </ul>;
+    }
+  },
+  trainingNeed: {
+    format: value => {
+      if (!value) {
+        return '-';
+      }
+      return <Markdown>{ value }</Markdown>;
+    }
+  },
+  project: {
+    format: project => {
+      return <Link page="project.read" establishmentId={project.establishmentId} projectId={project.id} label={project.title} />;
+    }
+  }
+};
+
+const PIL = (pil) => {
+  const licenceNumber = useSelector(state => state.model.pilLicenceNumber);
+
+  return <section className="profile-section">
+    <ModelSummary
+      model={{ ...pil, licenceNumber: pil.licenceNumber || licenceNumber }}
+      formatters={formatters}
+      schema={pilSchema}
+    />
+  </section>;
+};
+
+const TrainingPIL = (pil) => {
+  return <section className="profile-section">
+    <ModelSummary
+      model={{ ...pil }}
+      formatters={formatters}
+      schema={trainingPilSchema}
+    />
+  </section>;
+};
+
+export default function PILsList() {
+  const name = useSelector(state => `${state.model.firstName} ${state.model.lastName}`);
+  const pils = useSelector(state => sortBy(state.model.pils || [], 'issueDate'));
+  const trainingPils = useSelector(state => sortBy(state.model.trainingPils || [], 'issueDate'));
+
+  return (
+    <Fragment>
+      <Header
+        title={name}
+        subtitle="Personal Licences"
+      />
+      { !!pils.length && <h3>All PILs</h3> }
+      {
+        pils.map(pil => <PIL key={pil.id} {...pil} />)
+      }
+      { !!trainingPils.length && <h3>Training licences</h3> }
+      {
+        trainingPils.map(pil => <TrainingPIL key={pil.id} {...pil} />)
+      }
+    </Fragment>
+  );
+}

--- a/pages/global-profile/routes.js
+++ b/pages/global-profile/routes.js
@@ -1,0 +1,12 @@
+const pils = require('./pils');
+
+module.exports = {
+  read: {
+    path: '/',
+    router: () => (req, res, next) => next()
+  },
+  pils: {
+    path: '/pils',
+    router: pils
+  }
+};

--- a/pages/global-profile/views/index.jsx
+++ b/pages/global-profile/views/index.jsx
@@ -32,6 +32,12 @@ export default function InternalGlobalProfile() {
   return (
     <GlobalProfile dedupe={dedupe} AsruRolesComponent={AsruActions}>
       {
+        !model.asruUser && <Fragment>
+          <h2>Personal licences</h2>
+          <p><Link page="globalProfile.pils" profileId={model.id} label="View complete PIL history" /></p>
+        </Fragment>
+      }
+      {
         model.asruInspector && model.asru && !!model.asru.length && <Fragment>
           <h3>Inspector for:</h3>
           <AsruAssociations establishments={model.asru} />


### PR DESCRIPTION
This allows ASRU to see other PILs associated with a profile that may not show up in the users primary PIL page.

This includes cases where a single user has more than one PIL record, or has multiple training PILs.