### PR TITLE
Fix errors loading list of ROP submissions

### DIFF
--- a/pages/reporting/details/task-list/content/index.js
+++ b/pages/reporting/details/task-list/content/index.js
@@ -46,6 +46,8 @@ module.exports = merge({}, tasklistContent, {
 
     'place-update': 'Approved area amendments granted',
     'place-create': 'Approved area additions granted',
-    'place-delete': 'Approved area deletions granted'
+    'place-delete': 'Approved area deletions granted',
+
+    'rop-submit': 'Return of procedures submissions'
   }
 });

--- a/pages/reporting/details/task-list/report-filters.js
+++ b/pages/reporting/details/task-list/report-filters.js
@@ -4,7 +4,7 @@ module.exports = ({ query, log }) => {
     schemaVersion,
     model,
     action
-  ] = report.match(/((all|legacy)-)?(project|pil|establishment|role|place)-([a-z-]+)/).slice(2);
+  ] = report.match(/((all|legacy)-)?(project|pil|establishment|role|place|rop)-([a-z-]+)/).slice(2);
 
   log('debug', { matches: {
     schemaVersion,


### PR DESCRIPTION
When clicking from the metrics page into the list of ROP submission tasks a selection of errors were being thrown.