### PR TITLE
Include the establishment status in the autocomplete

### DIFF
--- a/pages/reporting/index.js
+++ b/pages/reporting/index.js
@@ -31,7 +31,7 @@ module.exports = settings => {
     req.api('/search/establishments', { query: { limit: 1000 } })
       .then(response => {
         res.locals.static.establishments = response.json.data.map(e => {
-          return { value: e.id, label: e.name };
+          return { value: e.id, label: e.name, status: e.status };
         });
       })
       .then(() => next())

--- a/pages/reporting/views/components/establishment-select.jsx
+++ b/pages/reporting/views/components/establishment-select.jsx
@@ -22,7 +22,12 @@ export default function AutoComplete(props) {
       source={search}
       templates={{
         inputValue: item => item ? item.label : '',
-        suggestion: item => item ? item.label : ''
+        suggestion: item => {
+          if (item && item.status !== 'active') {
+            return `${item.label} (${item.status === 'inactive' ? 'draft' : item.status})`;
+          }
+          return item ? item.label : '';
+        }
       }}
       onConfirm={option => setValue(option ? option.value : '')}
       defaultValue={defaultValue}


### PR DESCRIPTION
This will help identify establishments that have been revoked and then regranted with a same or similar name.