### PR TITLE
Allow total column to sort itself

### DIFF
--- a/pages/licence-fees/establishments/schema/index.js
+++ b/pages/licence-fees/establishments/schema/index.js
@@ -29,7 +29,6 @@ module.exports = {
   establishment: {},
   personal: {},
   total: {
-    show: true,
-    sort: 'numberOfPils'
+    show: true
   }
 };


### PR DESCRIPTION
Since we're no longer doing an actual direct database query to get the data for this table we don't need to use the number of PILs as a proxy for the total fees for an establishment, and can sort on the total directly.