### PR TITLE
Fix cancel link in establishment create page

### DIFF
--- a/pages/create-establishment/index.js
+++ b/pages/create-establishment/index.js
@@ -19,7 +19,7 @@ module.exports = settings => {
     schema,
     cancelEdit: (req, res, next) => {
       delete req.session.form[req.model.id];
-      return res.redirect(req.buildRoute('search'));
+      return res.redirect(req.buildRoute('search', { searchType: 'establishments' }));
     }
   }));
 

--- a/pages/create-establishment/views/index.jsx
+++ b/pages/create-establishment/views/index.jsx
@@ -1,14 +1,17 @@
 import React, { Fragment } from 'react';
 import { FormLayout, Header, Snippet } from '@asl/components';
 
+const CancelLink = () => {
+  return <a href="?clear=true"><Snippet>buttons.cancel</Snippet></a>;
+};
+
 const Index = () => {
   return (
     <Fragment>
-      <FormLayout>
+      <FormLayout cancelLink={<CancelLink />}>
         <Header title={<Snippet>title</Snippet>} />
         <p><Snippet>summary</Snippet></p>
       </FormLayout>
-      <a href="?clear=true"><Snippet>buttons.cancel</Snippet></a>
     </Fragment>
   );
 };


### PR DESCRIPTION
Clicking the link resulted in an error page for a missing URL parameter. Add that to the redirect so it works correctly.

Also use `cancelLink` prop to pass the component so it renders nicely inline.