### PR TITLE
Add label for transferred projects in search filters

### DIFF
--- a/pages/search/content/projects-content.js
+++ b/pages/search/content/projects-content.js
@@ -46,7 +46,8 @@ module.exports = {
         active: 'Active projects',
         revoked: 'Revoked projects',
         expired: 'Expired projects',
-        inactive: 'Draft projects'
+        inactive: 'Draft projects',
+        transferred: 'Transferred projects'
       }
     },
     purposes: {


### PR DESCRIPTION
This was missing because the test data didn't include any completed transfers and the values are the result of elasticsearch aggregations.