### PR TITLE
Allow removal of CJSM email from establishment

### DIFF
--- a/pages/cjsm/content/index.js
+++ b/pages/cjsm/content/index.js
@@ -7,7 +7,6 @@ module.exports = {
   },
   errors: {
     cjsmEmail: {
-      required: 'Enter the CJSM email address',
       match: 'Enter a valid email address'
     }
   },

--- a/pages/cjsm/index.js
+++ b/pages/cjsm/index.js
@@ -20,7 +20,7 @@ module.exports = () => {
       method: 'PUT',
       json: {
         data: {
-          cjsmEmail
+          cjsmEmail: cjsmEmail || null
         }
       }
     };

--- a/pages/cjsm/schema/index.js
+++ b/pages/cjsm/schema/index.js
@@ -2,9 +2,8 @@ module.exports = {
   cjsmEmail: {
     inputType: 'inputText',
     validate: [
-      'required',
       {
-        match: /^\S+@\S+$/
+        match: /^(\S+@\S+)?$/
       }
     ]
   }


### PR DESCRIPTION
These are not mandatory, and one establishment has stopped using theirs so ASRU want to remove it.

* remove required validator
* accept an empty string in match regex
* send `null` to API if no value is entered so that database jsonschema validation does not try to match the format of `''` to an email