### PR TITLE
Add a hidden page to download internal deadlines report CSV

### DIFF
--- a/pages/common/content/index.js
+++ b/pages/common/content/index.js
@@ -1,6 +1,7 @@
 module.exports = {
   breadcrumbs: {
     reporting: 'Performance metrics',
+    taskMetrics: 'Task durations and decisions',
     fees: 'Licence fees',
     nts: 'Non-technical summaries',
     downloads: 'Downloads',

--- a/pages/reporting/routes.js
+++ b/pages/reporting/routes.js
@@ -1,5 +1,6 @@
 const download = require('./download');
 const details = require('./details');
+const taskMetrics = require('./task-metrics');
 
 module.exports = {
   download: {
@@ -11,5 +12,10 @@ module.exports = {
     breadcrumb: false,
     path: '/details',
     router: details
+  },
+  taskMetrics: {
+    breadcrumb: 'taskMetrics',
+    path: '/task-metrics',
+    router: taskMetrics
   }
 };

--- a/pages/reporting/task-metrics/content/index.js
+++ b/pages/reporting/task-metrics/content/index.js
@@ -1,0 +1,13 @@
+module.exports = {
+  page: {
+    title: 'Tasks processed by duration and decision',
+    description: `Download a monthly report broken down by task type including:
+
+     * The number of task processing targets exceeded
+
+    New reports become available on the 1st of each month.`
+  },
+  links: {
+    taskMetrics: 'Tasks processed by duration and decision for {{month}} {{year}}'
+  }
+};

--- a/pages/reporting/task-metrics/index.js
+++ b/pages/reporting/task-metrics/index.js
@@ -1,0 +1,52 @@
+const moment = require('moment');
+const csv = require('csv-stringify');
+const { page } = require('@asl/service/ui');
+
+module.exports = settings => {
+  const app = page({
+    ...settings,
+    root: __dirname
+  });
+
+  const reports = () => {
+    const earliest = moment('2021-12-01');
+    const latest = moment().startOf('month');
+    const months = [];
+    let date = earliest;
+
+    // eslint-disable-next-line no-unmodified-loop-condition
+    while (date < latest) {
+      months.unshift({ year: date.format('YYYY'), month: date.format('MMMM'), path: `/${date.format('YYYY/MM')}` });
+      date.add(1, 'month');
+    }
+
+    return months;
+  };
+
+  app.get('/', (req, res, next) => {
+    res.locals.static.reports = reports();
+    next();
+  });
+
+  app.get('/:year/:month', (req, res, next) => {
+    const query = req.params;
+
+    res.attachment('task-targets.csv');
+    const stringifier = csv({ bom: true, header: true });
+
+    return req.api('/reports/task-metrics', { query })
+      .then(response => {
+        const data = response.json.data;
+        if (data.length > 0) {
+          data.forEach(row => stringifier.write(row));
+        } else {
+          stringifier.write({ note: 'no tasks exceeded their internal targets this month' });
+        }
+        stringifier.pipe(res);
+        return stringifier.end();
+      })
+      .catch(next);
+  });
+
+  return app;
+};

--- a/pages/reporting/task-metrics/views/index.jsx
+++ b/pages/reporting/task-metrics/views/index.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { Header, Link, Snippet } from '@asl/components';
+
+export default function Index() {
+  const { reports } = useSelector(state => state.static);
+
+  return (
+    <div className="govuk-grid-row">
+      <div className="govuk-grid-column-three-quarters">
+        <Header title={<Snippet>page.title</Snippet>} />
+        <Snippet>page.description</Snippet>
+
+        {
+          reports.map(report => (
+            <p key={report.path}>
+              <Link
+                page="reporting.taskMetrics"
+                suffix={report.path}
+                label={<Snippet year={report.year} month={report.month}>links.taskMetrics</Snippet>}
+              />
+            </p>
+          ))
+        }
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
This page is not currently linked from anywhere and the URL `/reporting/task-metrics` will need to be manually entered in the address bar to access it.

Only the internal deadlines report is currently included. This report is only valid from when we started adding internal deadline dates to the task data, so it's limited to last month onwards.

The page currently looks like this:
<img width="1271" alt="task-metrics-page" src="https://user-images.githubusercontent.com/1880478/148410655-249c9cbc-d1ce-40ee-ac4d-59ae7ac60661.png">

