### PR TITLE
Add updatedAt column to licence fees export

### DIFF
--- a/pages/licence-fees/establishments/schema/index.js
+++ b/pages/licence-fees/establishments/schema/index.js
@@ -23,6 +23,9 @@ module.exports = {
   otherInformation: {
     accessor: 'billing.otherInformation'
   },
+  updatedAt: {
+    accessor: 'billing.updatedAt'
+  },
   numberOfPils: {
     show: true
   },


### PR DESCRIPTION
This shows ASRU business support who might have out-of-date contact information or PO numbers.