### PR TITLE
Fix missing content error on task search

### DIFF
--- a/.auditignore
+++ b/.auditignore
@@ -1,6 +1,3 @@
-1007129 && backpack-transpiled>*
+backpack-transpiled>*
 # need to include react-google-maps because of npm issue with building complete paths
-1007129 && react-google-maps>*
-
-# this isn't actually a webpack dependency (which should be ignored by --production) but npm audit ignores @asl/* scoped modules, so the child dependency of @asl/service reports as webpack.
-1006947 && webpack>*
+react-google-maps>*

--- a/pages/search/schema/tasks.js
+++ b/pages/search/schema/tasks.js
@@ -7,11 +7,6 @@ module.exports = {
     sortable: false,
     accessor: 'establishment.name'
   },
-  licence: {
-    show: true,
-    sortable: false,
-    accessor: 'model'
-  },
   type: {
     show: true,
     sortable: false,
@@ -20,6 +15,10 @@ module.exports = {
   status: {
     show: true,
     sortable: false
+  },
+  activeDeadline: {
+    show: true,
+    sortable: true
   },
   assignedTo: {
     show: true,


### PR DESCRIPTION
Update the schema in line with the task list schema to remove the `licence` column and prevent missing content error.