### PR TITLE
Add content label for pending PIL

### DIFF
--- a/pages/search/content/profiles.js
+++ b/pages/search/content/profiles.js
@@ -23,6 +23,7 @@ module.exports = {
   status: {
     active: 'Active',
     revoked: 'Revoked',
-    suspended: 'Suspended'
+    suspended: 'Suspended',
+    pending: 'Pending'
   }
 };


### PR DESCRIPTION
This currently throws an error if a page of the search results includes someone with a PIL application in progress.