### PR TITLE
[ASL-4289] token wrangling for publishing 

### DIFF
--- a/.drone-1.0.yml
+++ b/.drone-1.0.yml
@@ -89,7 +89,7 @@ steps:
     image: quay.io/ukhomeofficedigital/asl-deploy-bot:latest
     environment:
       GITHUB_ACCESS_TOKEN:
-        from_secret: github_token
+        from_secret: github_access_token
     commands:
       - update
         --repo ukhomeoffice/asl-deployments

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "asl-internal-ui",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "asl-internal-ui",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asl-internal-ui",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
asl-deploy-bot seems to fail when using the new github token:

```
+ update --repo ukhomeoffice/asl-deployments --token ${GITHUB_ACCESS_TOKEN} --file versions.yml --service asl-internal-ui --version ${DRONE_COMMIT_SHA}
{ HttpError: {"message":"Not Found","documentation_url":"https://docs.github.com/rest/reference/git#get-a-reference"}

```

let's try with the previous one. if it fails we need to find out what's necessary to make this step pass